### PR TITLE
Acerta nome da classe de migration

### DIFF
--- a/database/migrations/2020_10_10_212904_create_livros_leandroramos_table.php
+++ b/database/migrations/2020_10_10_212904_create_livros_leandroramos_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateLivrosLeandroRamosTable extends Migration
+class CreateLivroLeandroRamosTable extends Migration
 {
     /**
      * Run the migrations.


### PR DESCRIPTION
Acertando o nome da classe, pois a migration não estava rodando com o outro nome